### PR TITLE
add encryption key note

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Options:
     -d DB_SYSTEM_ID_VALUE, --db-system-id-value=DB_SYSTEM_ID_VALUE
                         (mandatory for v4): machine-unique value of
                         "db.system.id" attribute in the "product-
-                        preferences.xml" file. Ex: -d 6b2f64b2-e83e-49a5-9abf-
-                        cb2cd7e3a9ee
+                        preferences.xml" file  or the export file encryption
+                        key. Ex: -d 6b2f64b2-e83e-49a5-9abf-cb2cd7e3a9ee
 ```
 
 Examples

--- a/sqldeveloperpassworddecryptor.jy
+++ b/sqldeveloperpassworddecryptor.jy
@@ -42,7 +42,7 @@ main_grp.add_option('-p', '--encrypted-password', help = '(mandatory): password 
 #main_grp.add_option('-c', '--connections-file', help = '(optional): "connections.xml" file containing encrypted passwords.', nargs = 1)
 
 v4_grp = OptionGroup(parser, 'v4 specific parameters')
-v4_grp.add_option('-d', '--db-system-id-value', help = '(mandatory for v4): machine-unique value of "db.system.id" attribute in the "product-preferences.xml" file. Ex: -d 6b2f64b2-e83e-49a5-9abf-cb2cd7e3a9ee', nargs = 1)
+v4_grp.add_option('-d', '--db-system-id-value', help = '(mandatory for v4): machine-unique value of "db.system.id" attribute in the "product-preferences.xml" file or the export file encryption key. Ex: -d 6b2f64b2-e83e-49a5-9abf-cb2cd7e3a9ee', nargs = 1)
 #v4_grp.add_option('-f', '--db-system-id-file', help = '(optional): "product-preferences.xml" file  containing the "db.system.id" attribute value.', nargs = 1)
 
 parser.option_groups.extend([main_grp, v4_grp])

--- a/sqldeveloperpassworddecryptor.py
+++ b/sqldeveloperpassworddecryptor.py
@@ -39,7 +39,7 @@ main_grp.add_option('-p', '--encrypted-password', help = '(mandatory): password 
 #main_grp.add_option('-c', '--connections-file', help = '(optional): "connections.xml" file containing encrypted passwords.', nargs = 1)
 
 v4_grp = OptionGroup(parser, 'v4 specific parameters')
-v4_grp.add_option('-d', '--db-system-id-value', help = '(mandatory for v4): machine-unique value of "db.system.id" attribute in the "product-preferences.xml" file. Ex: -d 6b2f64b2-e83e-49a5-9abf-cb2cd7e3a9ee', nargs = 1)
+v4_grp.add_option('-d', '--db-system-id-value', help = '(mandatory for v4): machine-unique value of "db.system.id" attribute in the "product-preferences.xml" file or the export file encryption key. Ex: -d 6b2f64b2-e83e-49a5-9abf-cb2cd7e3a9ee', nargs = 1)
 #v4_grp.add_option('-f', '--db-system-id-file', help = '(optional): "product-preferences.xml" file  containing the "db.system.id" attribute value.', nargs = 1)
 
 parser.option_groups.extend([main_grp, v4_grp])


### PR DESCRIPTION
When exporting one or more connections from SQLDeveloper 4, an
encryption key must be entered. In the resulting XML file, the passwords
are encrypted at usual, but instead of the system-id value the entered
key is used.
